### PR TITLE
Wrap onSelect callback in the Ember run loop

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -10,7 +10,11 @@ export default Ember.Component.extend({
 
     var options = {
       field: this.$()[0],
-      onSelect: function() { that.userSelectedDate(); },
+      onSelect: function() {
+        Ember.run(function() {
+          that.userSelectedDate();
+        });
+      },
       firstDay: 1,
       format: this.get('format') || 'DD.MM.YYYY'
     };


### PR DESCRIPTION
As described in the [Ember documentation](http://emberjs.com/guides/understanding-ember/run-loop/#toc_what-scenarios-will-require-me-to-understand-the-run-loop), non-Ember callbacks should be wrapped in the Ember run loop.
