### PR TITLE
set autocomplete to off as default

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -19,6 +19,7 @@ export default Ember.Component.extend(PikadayMixin, {
   ],
 
   type: 'text',
+  autocomplete: false,
 
   didInsertElement() {
     this.set('field', this.element);


### PR DESCRIPTION
I think we should disable autocomplete as default. Otherwise things get ugly in Edge.

![image](https://user-images.githubusercontent.com/1208273/34264178-47f59752-e672-11e7-8df0-2ac2770f096c.png)
