### PR TITLE
Allow minDate & maxDate to be reset

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -155,6 +155,8 @@ export default Mixin.create({
           pikaday.setDate(minDate);
         }
       });
+    } else {
+      pikaday.setMinDate(null);
     }
   },
 
@@ -175,6 +177,8 @@ export default Mixin.create({
           pikaday.setDate(maxDate);
         }
       });
+    } else {
+      pikaday.setMaxDate(null);
     }
   },
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,6 +5,9 @@ export default Controller.extend({
   startDate: undefined,
   today: undefined,
 
+  isMinDateSet: true,
+  isMaxDateSet: true,
+
   init() {
     this._super(...arguments);
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,13 +7,13 @@ Standalone datepicker:
 
 <br>
 
-Datepicker with minDate:
+Datepicker with minDate set to today ({{input type="checkbox" checked=isMinDateSet}}) and maxDate set to today ({{input type="checkbox" checked=isMaxDateSet}}):
 {{pikaday-input
-  minDate=today
+  minDate=(if isMinDateSet today null)
+  maxDate=(if isMaxDateSet today null)
   value=someDate
   onSelection=(action (mut someDate))
 }}
-
 <br>
 
 Datepicker with bound and set value:

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -145,6 +145,20 @@ test('set min date', function(assert) {
   assert.ok($('.is-today').hasClass('is-disabled'));
 });
 
+test('reset min date', function(assert) {
+  var tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  this.set('tomorrow', tomorrow);
+  this.render(hbs`{{pikaday-input minDate=tomorrow}}`);
+  this.set('tomorrow', null);
+
+  run(() => {
+    this.$('input').click();
+  });
+
+  assert.ok(!$('.is-today').hasClass('is-disabled'));
+});
+
 test('set max date', function(assert) {
   var yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
@@ -156,6 +170,20 @@ test('set max date', function(assert) {
   });
 
   assert.ok($('.is-today').hasClass('is-disabled'));
+});
+
+test('reset max date', function(assert) {
+  var yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  this.set('yesterday', yesterday);
+  this.render(hbs`{{pikaday-input maxDate=yesterday}}`);
+  this.set('yesterday', null);
+
+  run(() => {
+    this.$('input').click();
+  });
+
+  assert.ok(!$('.is-today').hasClass('is-disabled'));
 });
 
 test('set new date value with a new min date', function(assert) {


### PR DESCRIPTION
Fixes #154
minDate and maxDate could never be reset to null because of the "if" condition. this should do the trick.