### PR TITLE
Cleanup scheduled task when component is torn down.

### DIFF
--- a/addon/mixins/pikaday.js
+++ b/addon/mixins/pikaday.js
@@ -70,7 +70,7 @@ export default Ember.Mixin.create({
 	 * @return {undefined}
 	 */
   didUpdateAttrs() {
-    run.later(() => {
+    this.set('cancelToken', run.later(() => {
       // Do not set or update anything when the component is destroying.
       if (this.get('isDestroying') || this.get('isDestroyed')) { return; }
 
@@ -81,7 +81,7 @@ export default Ember.Mixin.create({
       if (this.get('options')) {
         this._updateOptions();
       }
-    });
+    }));
   },
 
   didRender() {
@@ -103,6 +103,7 @@ export default Ember.Mixin.create({
   willDestroyElement() {
     this._super();
     this.get('pikaday').destroy();
+    run.cancel(this.get('cancelToken'));
   },
 
   setPikadayDate: function() {


### PR DESCRIPTION
Failure to cancel the task scheduled by `run.later` can result in an attempt to interact with the component after it has already been destroyed.  This can cause errors in the browser console and it can cause failures of frontend tests.