### PR TITLE
fix: Bind autocomplete attribute to `"off"` instead of `"false"`

### DIFF
--- a/addon/components/pikaday-input.js
+++ b/addon/components/pikaday-input.js
@@ -20,7 +20,7 @@ export default Component.extend(PikadayMixin, {
   ],
 
   type: 'text',
-  autocomplete: false,
+  autocomplete: 'off',
 
   didInsertElement() {
     this.set('field', this.element);


### PR DESCRIPTION
This is happening on Ember 3.4.7/Chrome 71.  The tests all assert correctly against `"off"` being the value.

This is likely a Ember/Glimmer/Chrome (unknown right now) but setting it `"off"` on the proto should work for those with bugged versions of Ember/Glimmer and those that correctly map `false` to `"off"`.