### PR TITLE
update to new repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pikaday",
     "datepicker"
   ],
-  "repository": "https://github.com/edgycircle/ember-pikaday",
+  "repository": "https://github.com/adopted-ember-addons/ember-pikaday",
   "license": "MIT",
   "author": "David Strauß",
   "directories": {


### PR DESCRIPTION
Per the [guidelines](https://github.com/adopted-ember-addons/program-guidelines#addon-transfer-checklist), the repository URL should link here.