### PR TITLE
Fixes testing of multiple pikaday inputs

### DIFF
--- a/addon-test-support/interactor.js
+++ b/addon-test-support/interactor.js
@@ -12,21 +12,28 @@ export async function selectDate(date) {
   const year = date.getFullYear();
   const selectEvent = 'ontouchend' in document ? 'touchend' : 'mousedown';
 
-  const yearElement = document.querySelector(YEAR_SELECTOR);
+  const yearElement = findVisibleElement(YEAR_SELECTOR);
   yearElement.value = year;
   await triggerEvent(yearElement, 'change');
 
-  const monthElement = document.querySelector(MONTH_SELECTOR);
+  const monthElement = findVisibleElement(MONTH_SELECTOR);
   monthElement.value = month;
   await triggerEvent(monthElement, 'change');
 
   await triggerEvent(
-    document.querySelector(
+    findVisibleElement(
       'td[data-day="' + day + '"]:not(.is-outside-current-month) button'
     ),
     selectEvent
   );
 }
+
+const findVisibleElement = function(selector) {
+  const elements = document.querySelectorAll(selector);
+  return Array.from(elements).find(function(e) {
+    return e.offsetParent != null;
+  });
+};
 
 export function selectedDay() {
   return document.querySelector('.pika-single td.is-selected button').innerHTML;

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -66,6 +66,30 @@ module('Integration | Component | pikaday-input', function(hooks) {
     await Interactor.selectDate(expectedDate);
   });
 
+  test('selecting multiple dates should send actions', async function(assert) {
+    const expectedDate1 = new Date(2013, 3, 28);
+    const expectedDate2 = new Date(2014, 4, 1);
+
+    this.set('onSelection1', function(selectedDate) {
+      assert.deepEqual(selectedDate, expectedDate1);
+    });
+
+    this.set('onSelection2', function(selectedDate) {
+      assert.deepEqual(selectedDate, expectedDate2);
+    });
+
+    await render(hbs`
+      {{pikaday-input onSelection=(action onSelection1) class="first"}}
+      {{pikaday-input onSelection=(action onSelection2) class="second"}}
+    `);
+
+    await click('input.first');
+    await Interactor.selectDate(expectedDate1);
+
+    await click('input.second');
+    await Interactor.selectDate(expectedDate2);
+  });
+
   test('clearing the date should send an action', async function(assert) {
     this.set('value', new Date(2010, 7, 10));
     this.set('onSelection', function(selectedDate) {


### PR DESCRIPTION
The removal of jquery #220 changed the test selectors so they no longer checked for visibility. So when selecting a date from the second or greater pikaday input on a page it would not fill out the correct inputs. This has been fixed by returning the first visible element rather than the first element in the dom. Checking `offsetParent` appears to be the best way of doing this.

I double checked and the test included here was passing in `v2.3.1`.