### PR TITLE
Replace `ember-cli-node-assets` with regular imports from `node_modules`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,21 @@
 /* eslint-env node */
 'use strict';
-const fastbootTransform = require('fastboot-transform');
 
 module.exports = {
   name: require('./package').name,
 
-  options: {
-    nodeAssets: {
-      pikaday: {
-        vendor: ['pikaday.js', 'css/pikaday.css'],
-        processTree(input) {
-          return fastbootTransform(input);
-        }
-      }
-    }
-  },
   included() {
     this._super.included.apply(this, arguments);
 
-    this.import('vendor/pikaday/pikaday.js');
-    this.import('vendor/pikaday/css/pikaday.css');
+    const dependencies = Object.keys(this.project.dependencies());
+    const hasFastboot = dependencies.includes('ember-cli-fastboot');
+
+    const importOptions = {};
+    if (hasFastboot) {
+      importOptions.using = [{ transformation: 'fastbootShim' }];
+    }
+
+    this.import('node_modules/pikaday/pikaday.js', importOptions);
+    this.import('node_modules/pikaday/css/pikaday.css');
   }
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
+    const addonOptions =
+      (this.app.options && this.app.options.emberPikaday) || {};
+
     const dependencies = Object.keys(this.project.dependencies());
     const hasFastboot = dependencies.includes('ember-cli-fastboot');
 
@@ -16,6 +19,8 @@ module.exports = {
     }
 
     this.import('node_modules/pikaday/pikaday.js', importOptions);
-    this.import('node_modules/pikaday/css/pikaday.css');
+    if (!addonOptions.excludePikadayAssets) {
+      this.import('node_modules/pikaday/css/pikaday.css');
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "ember-cli-babel": "^6.16.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-moment-shim": "^3.6.0",
-    "ember-cli-node-assets": "^0.2.2",
-    "fastboot-transform": "^0.1.1",
     "pikaday": "^1.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,7 +1413,7 @@ broccoli-kitchen-sink-helpers@^0.3.1:
     glob "^5.0.10"
     mkdirp "^0.5.1"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
+broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -2176,7 +2176,7 @@ continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
 
-convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2648,17 +2648,6 @@ ember-cli-moment-shim@^3.6.0:
     lodash.defaults "^4.2.0"
     moment "^2.19.3"
     moment-timezone "^0.5.13"
-
-ember-cli-node-assets@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-source "^1.1.0"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -3620,13 +3609,6 @@ fast-sourcemap-concat@^1.4.0:
     source-map "^0.4.2"
     source-map-url "^0.3.0"
     sourcemap-validator "^1.1.0"
-
-fastboot-transform@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/fastboot-transform/-/fastboot-transform-0.1.3.tgz#7dea0b117594afd8772baa6c9b0919644e7f7dcd"
-  dependencies:
-    broccoli-stew "^1.5.0"
-    convert-source-map "^1.5.1"
 
 faye-websocket@~0.10.0:
   version "0.10.0"
@@ -5720,10 +5702,13 @@ lodash.values@~2.3.0:
   dependencies:
     lodash.keys "~2.3.0"
 
-lodash@4.17.11, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.2:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -7339,7 +7324,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@1.5.0, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
+resolve@1.5.0, resolve@^1.1.6, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION
As mentioned in the README of https://github.com/dfreeman/ember-cli-node-assets the addon is essentially deprecated because Ember CLI supports the same thing natively these days.

This might be considered a breaking change as it will raise the minimum supported Ember CLI version to v2.16.

Resolves #122 

/cc @efx 