### PR TITLE
Prefer moment's localeData methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ export default {
     let i18n = EmberObject.extend({
       previousMonth: 'Vorheriger Monat',
       nextMonth: 'Nächster Monat',
-      months: moment.localeData()._months,
-      weekdays: moment.localeData()._weekdays,
-      weekdaysShort: moment.localeData()._weekdaysShort
+      months: moment.localeData().months(),
+      weekdays: moment.localeData().weekdays(),
+      weekdaysShort: moment.localeData().weekdaysShort()
     });
 
     application.register('pikaday-i18n:main', i18n, { singleton: true });

--- a/tests/dummy/app/initializers/setup-pikaday-i18n.js
+++ b/tests/dummy/app/initializers/setup-pikaday-i18n.js
@@ -7,9 +7,9 @@ export default {
     const i18n = EmberObject.extend({
       previousMonth: 'Vorheriger Monat',
       nextMonth: 'Nächster Monat',
-      months: moment.localeData()._months,
-      weekdays: moment.localeData()._weekdays,
-      weekdaysShort: moment.localeData()._weekdaysShort
+      months: moment.localeData().months(),
+      weekdays: moment.localeData().weekdays(),
+      weekdaysShort: moment.localeData().weekdaysShort()
     });
 
     const container = arguments[0];


### PR DESCRIPTION
The `_months`, `_weekdays`, and `_weekdaysShort` properties suggested in the readme are internal moment.js methods. Using [documented, external versions of those](https://momentjs.com/docs/#/i18n/listing-months-weekdays/) (e.g. `months()`) is less prone to regressions.

This fixes https://github.com/adopted-ember-addons/ember-pikaday/issues/222 : months show as 'undefined' in Russian