### PR TITLE
Add test helper to open, select date and close the Pikaday

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can also pass in other closure actions to handle `onOpen`, `onClose` and `on
 ```handlebars
 <label>
   Start date:
-  <PikadayInput 
-    @onOpen={{action 'doSomethingOnOpen'}} 
+  <PikadayInput
+    @onOpen={{action 'doSomethingOnOpen'}}
     @onClose={{action 'doSomethingOnClose'}}
     @onDraw={{action 'doSomethingOnDraw'}}
   />
@@ -282,7 +282,7 @@ Pikaday can be closed with the provided `close` helper:
 ```js
 import { close as closePikaday } from 'ember-pikaday/test-support';
 
-await closePikaday('.my-pikaday-input');
+await closePikaday();
 ```
 
 ### Interacting with Pikaday
@@ -305,6 +305,24 @@ await Interactor.selectDate(new Date(1989, 3, 28));
 assert.equal(Interactor.selectedYear(), 1989);
 assert.equal(Interactor.selectedMonth(), 3);
 assert.equal(Interactor.selectedDay(), 28);
+```
+
+### Opening, Interacting and Closing
+
+Pikaday can be opened, a date selected, and then closed using the `fillInDate` test helper:
+
+```js
+import { fillInDate } from 'ember-pikaday/test-support';
+
+await fillInDate('.my-pikaday-input', new Date(1989, 3, 28));
+```
+
+This is equivalent to:
+
+```js
+await click('.my-pikaday-input');
+await Interactor.selectDate(new Date(1989, 3, 28));
+await closePikaday();
 ```
 
 ## Excluding assets

--- a/addon-test-support/fill-in-date.js
+++ b/addon-test-support/fill-in-date.js
@@ -1,9 +1,9 @@
-import * as Interactor from './interactor';
 import { click } from '@ember/test-helpers';
+import { selectDate } from './interactor';
 import close from './close-pikaday';
 
 export default async function fillInDate(selector, date) {
   await click(selector);
-  await Interactor.selectDate(date);
+  await selectDate(date);
   await close();
 }

--- a/addon-test-support/fill-in-date.js
+++ b/addon-test-support/fill-in-date.js
@@ -1,0 +1,9 @@
+import * as Interactor from './interactor';
+import { click } from '@ember/test-helpers';
+import close from './close-pikaday';
+
+export default async function fillInDate(selector, date) {
+  await click(selector);
+  await Interactor.selectDate(date);
+  await close();
+}

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -2,3 +2,4 @@ import * as Interactor from './interactor';
 
 export { Interactor };
 export { default as close } from './close-pikaday';
+export { default as fillInDate } from './fill-in-date';

--- a/tests/integration/components/pikaday-input-test.js
+++ b/tests/integration/components/pikaday-input-test.js
@@ -3,7 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn, settled } from '@ember/test-helpers';
 import findAll from 'ember-pikaday/test-support/-private/find-all';
 import hbs from 'htmlbars-inline-precompile';
-import { close as closePikaday, Interactor } from 'ember-pikaday/test-support';
+import {
+  close as closePikaday,
+  fillInDate,
+  Interactor
+} from 'ember-pikaday/test-support';
 import td from 'testdouble';
 
 const getFirstWeekendDayNumber = function() {
@@ -739,5 +743,28 @@ module('Integration | Component | pikaday-input', function(hooks) {
     assert.equal(Interactor.selectedYear(), 2018);
     assert.equal(Interactor.selectedMonth(), 5);
     assert.equal(Interactor.selectedDay(), 28);
+  });
+
+  test('it selects dates when using multiple date pickers', async function(assert) {
+    const startsAt = new Date(2018, 5, 18);
+    const expiresAt = new Date(2018, 5, 28);
+
+    await render(hbs`
+      <PikadayInput
+        @onSelection={{action (mut this.startsAt)}}
+        name="starts-at"
+      />
+
+      <PikadayInput
+        @onSelection={{action (mut this.expiresAt)}}
+        name="expires-at"
+      />
+    `);
+
+    await fillInDate('input[name="starts-at"]', startsAt);
+    await fillInDate('input[name="expires-at"]', expiresAt);
+
+    assert.deepEqual(this.startsAt, startsAt, 'starts-at');
+    assert.deepEqual(this.expiresAt, expiresAt, 'expires-at');
   });
 });


### PR DESCRIPTION
Pikaday can now be opened, a date selected, and then closed using the `fillInDate` test helper:

```js
import { fillInDate } from 'ember-pikaday/test-support';

await fillInDate('.my-pikaday-input', new Date(1989, 3, 28));
```

This is equivalent to:

```js
await click('.my-pikaday-input');
await Interactor.selectDate(new Date(1989, 3, 28));
await closePikaday();
```

Closes #231 