### PR TITLE
fix: Prevent ember-pikaday from automatically updating values to within a min/max date bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ All other named arguments are passed directly to Pikaday, so see [Pikaday's conf
 
 The only behaviors this modifier adds to the stock Pikaday are:
 
-- if you set `minDate` or `maxDate` and that causes `value` to be outside the legal range, we adjust `value` and fire `onSelect` to inform you of the change
 - if you set your `<input>` element's `disabled` attribute we will close Pikaday if it had been open.
 
 ### &lt;PikadayInput&gt; Component

--- a/src/modifiers/pikaday.js
+++ b/src/modifiers/pikaday.js
@@ -54,21 +54,9 @@ export default class PikadayModifier extends Modifier {
       this.#observer.observe(element, { attributes: true });
       register?.(this.#pikaday);
     } else {
-      let { value, minDate, maxDate } = named;
-      let valueAltered = false;
-      this.#pikaday.setMinDate(copyDate(minDate));
-      if (minDate && value && value < minDate) {
-        value = minDate;
-        valueAltered = true;
-      }
+      let { value } = named;
 
-      this.#pikaday.setMaxDate(copyDate(maxDate));
-      if (maxDate && value && value > maxDate) {
-        value = maxDate;
-        valueAltered = true;
-      }
-
-      this.#pikaday.setDate(value, !valueAltered);
+      this.#pikaday.setDate(value, true);
       this.#pikaday.config(pikadayOptions);
     }
   }
@@ -77,14 +65,5 @@ export default class PikadayModifier extends Modifier {
     if (element.hasAttribute('disabled')) {
       this.#pikaday.hide();
     }
-  }
-}
-
-// apparently Pikaday mutates Dates that you pass it for minDate and maxDate. <sigh>
-function copyDate(date) {
-  if (date) {
-    return new Date(date.getTime());
-  } else {
-    return date;
   }
 }

--- a/test-app/tests/integration/components/pikaday-input-test.js
+++ b/test-app/tests/integration/components/pikaday-input-test.js
@@ -253,7 +253,12 @@ module('Integration | Component | pikaday-input', function (hooks) {
     this.set('tomorrow', new Date(2010, 7, 9));
     await settled();
 
-    assert.dom('input').hasValue('09.08.2010');
+    assert
+      .dom('input')
+      .hasValue(
+        '10.08.2010',
+        'we do not manipulate the value even if it violates minDate'
+      );
   });
 
   test('set new date value with a new max date', async function (assert) {
@@ -267,7 +272,12 @@ module('Integration | Component | pikaday-input', function (hooks) {
     this.set('tomorrow', new Date(2010, 7, 11));
     await settled();
 
-    assert.dom('input').hasValue('11.08.2010');
+    assert
+      .dom('input')
+      .hasValue(
+        '10.08.2010',
+        'we do not manipulate the value, even if it violates the maxDate'
+      );
   });
 
   test('theme option adds theme as CSS class to DOM element', async function (assert) {
@@ -590,58 +600,6 @@ module('Integration | Component | pikaday-input', function (hooks) {
     );
 
     assert.dom(disabledWeekendCell).doesNotHaveClass('is-disabled');
-  });
-
-  test("if minDate is greater than value we set pikaday's current date to minDate", async function (assert) {
-    assert.expect(1);
-
-    const today = new Date();
-    const tomorrow = new Date(Date.now() + 60 * 60 * 24 * 1000);
-
-    this.set('currentDate', today);
-    this.set('minDate', today);
-    this.set('updateCurrentDate', (date) => {
-      this.set('currentDate', date);
-    });
-
-    await render(hbs`
-      <PikadayInput @minDate={{this.minDate}} @value={{this.currentDate}} @onSelection={{this.updateCurrentDate}}/>
-    `);
-
-    this.set('minDate', tomorrow);
-    await settled();
-
-    assert.equal(
-      this.currentDate.getDate(),
-      tomorrow.getDate(),
-      'value should change'
-    );
-  });
-
-  test("if maxDate is lower than value we set pikaday's current date to maxDate", async function (assert) {
-    assert.expect(1);
-
-    const today = new Date();
-    const tomorrow = new Date(Date.now() + 60 * 60 * 24 * 1000);
-
-    this.set('currentDate', tomorrow);
-    this.set('maxDate', tomorrow);
-    this.set('updateCurrentDate', (date) => {
-      this.set('currentDate', date);
-    });
-
-    await render(hbs`
-      <PikadayInput @maxDate={{this.maxDate}} @value={{this.currentDate}} @onSelection={{this.updateCurrentDate}}/>
-    `);
-
-    this.set('maxDate', today);
-    await settled();
-
-    assert.equal(
-      this.currentDate.getDate(),
-      today.getDate(),
-      'value should change'
-    );
   });
 
   test("if value is null we don't enforce minDate or maxDate", async function (assert) {


### PR DESCRIPTION
If merged, ember-pikaday will no longer enforce a min/max date restriction.  

Original issue: https://github.com/adopted-ember-addons/ember-pikaday/issues/581

Ember-pikaday was running code in the modifier that would update the value to the min/max date if that value was outside of the min/max date bounds. This code was causing issues as it would update the value in the same loop that the value was read.  Creating exceptions.  

The readme used to have this text,  we are getting rid of this: 
```markdown
- if you set `minDate` or `maxDate` and that causes `value` to be outside the legal range, we adjust `value` and fire `onSelect` to inform you of the change
```

* Removes code that forces the 'value' to be within a `minDate` or `maxDate` restriction
* Updates tests
* Removes mention of this feature from the readme