### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: pnpm
     directory: '/'
     schedule:
       interval: weekly


### PR DESCRIPTION
If merged, this would correct the issue where npm was still declared as the package-ecosystem in the configuration file, instead of pnpm