### PR TITLE
Include addon-main.cjs in package.json#files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "./pikaday.css": "./vendor/pikaday.css"
   },
   "files": [
-    "addon-main.js",
+    "addon-main.cjs",
     "dist",
     "vendor/pikaday.css"
   ],


### PR DESCRIPTION
this was missed when renamed `addon-main.js` → `addon-main.cjs` in #626